### PR TITLE
Python is deprecating simple 'if <elem>:' tests, so remove those to c…

### DIFF
--- a/feed-fiddler
+++ b/feed-fiddler
@@ -221,7 +221,7 @@ def fiddle_append_to_title(feed, config):
     title.text = new_title
 
     imagetitle = feed.find('channel/image/title')
-    if imagetitle:
+    if imagetitle is not None:
         new_title = (f"{imagetitle.text} {config['string']}")
         imagetitle.text = new_title
 
@@ -240,7 +240,7 @@ def fiddle_replace_title(feed, config):
 def fiddle_replace_feed_image(feed, config):
     logging.info(f"Editing image to '{config['url']}'")
     image_url = feed.find('channel/image/url')
-    if image_url:
+    if image_url is not None:
         image_url.text = config['url']
     #TODO: Fixup images defined in other ways (like se2kb)
 


### PR DESCRIPTION
…lose #12

warning was:

/home/avi/repos/feed-fiddler/./feed-fiddler:224: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
  if imagetitle: